### PR TITLE
Make api-client standalone

### DIFF
--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -21,47 +21,47 @@ class DeonRestClient implements DeonApi {
   contracts: ContractsApi = {
     getAll: () => this.http.get('/contracts'),
 
-    get: (id: string) => this.http.get('/contracts/' + id),
+    get: (id: string) => this.http.get(`/contracts/${id}`),
 
-    tree: (id: string) => this.http.get('/contracts/' + id + '/tree'),
+    tree: (id: string) => this.http.get(`/contracts/${id}/tree`),
 
     src: (id: string, simplified: boolean) => {
       const url = simplified ? `/contracts/${id}/src/?simplified=true` : `/contracts/${id}/src`;
       return this.http.get(url);
     },
 
-    nextEvents: (id: string) => this.http.get('/contracts/' + id + '/next-events'),
+    nextEvents: (id: string) => this.http.get(`/contracts/${id}/next-events`),
 
     instantiate: (instantiateInput: InstantiationInput) =>
       this.http.post('/contracts', instantiateInput),
 
     applyEvent: (id: string, event: Event, tag?: Tag) => {
-      if (tag) return this.http.post('/contracts/' + id + '/' + tag + '/events', event);
-      return this.http.post('/contracts/' + id + '/events', event);
+      if (tag) return this.http.post(`/contracts/${id}/${tag}/events`, event);
+      return this.http.post(`/contracts/${id}/events`, event);
     },
 
     report: (expressionInput: ExpressionInput) =>
       this.http.post('/contracts/report', expressionInput),
 
     reportOnContract: (id: string, expressionInput: ExpressionInput) =>
-      this.http.post('/contracts/' + id + '/report', expressionInput),
+      this.http.post(`/contracts/${id}/report`, expressionInput),
   };
 
   declarations: DeclarationsApi = {
     getAll: () => this.http.get('/declarations'),
 
-    get: (id: string) => this.http.get('/declarations/' + id),
+    get: (id: string) => this.http.get(`/declarations/${id}`),
 
     add: (i: DeclarationInput) => this.http.post('/declarations', i),
 
-    ontology: (id: string) => this.http.get('/declarations/' + id + '/ontology'),
+    ontology: (id: string) => this.http.get(`/declarations/${id}/ontology`),
   };
 
   csl: CslApi = {
     check: (i: ExpressionInput) => this.http.post('/csl/check', i),
 
     checkExpression: (i: ExpressionInput, id?: string) => {
-      if (id) return this.http.post('/csl/check-expression/' + id, i);
+      if (id) return this.http.post(`/csl/check-expression/${id}`, i);
       return this.http.post('/csl/check-expression', i);
     },
 

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -1,71 +1,74 @@
-import { DeonApi, ContractsApi, DeclarationsApi, CslApi, InfoApi, RestResponse } from './DeonApi';
+import { DeonApi, ContractsApi, DeclarationsApi, CslApi, InfoApi } from './DeonApi';
 import { InstantiationInput, ExpressionInput, DeclarationInput, Event, Tag } from './DeonData';
+import { HttpClient, Response } from './HttpClient';
 
 /**
  * Constructs a Deon REST client.
  */
 class DeonRestClient implements DeonApi {
-  private get: <TOk, TErr>(url: string) => Promise<RestResponse<TOk, TErr>>;
-  private post: <TOk, TErr>(url: string, data: object) => Promise<RestResponse<TOk, TErr>>;
+  private http: HttpClient;
 
-  constructor(
-    get: <TOk, TErr>(url: string) => Promise<RestResponse<TOk, TErr>>,
-    post: <TOk, TErr>(url: string, data: object) => Promise<RestResponse<TOk, TErr>>,
-  ) {
-    this.get = get;
-    this.post = post;
+  constructor(http: HttpClient) {
+    this.http = http;
   }
 
+  static create = (
+    fetch: (url: any, init: any) => Promise<Response>,
+    serverUrl: string = '',
+    hook: (r: Response) => PromiseLike<Response> | Response = r => r,
+  ) => new DeonRestClient(new HttpClient(fetch, hook, serverUrl))
+
   contracts: ContractsApi = {
-    getAll: () => this.get('/contracts'),
+    getAll: () => this.http.get('/contracts'),
 
-    get: (id: string) => this.get('/contracts/' + id),
+    get: (id: string) => this.http.get('/contracts/' + id),
 
-    tree: (id: string) => this.get('/contracts/' + id + '/tree'),
+    tree: (id: string) => this.http.get('/contracts/' + id + '/tree'),
 
     src: (id: string, simplified: boolean) => {
       const url = simplified ? `/contracts/${id}/src/?simplified=true` : `/contracts/${id}/src`;
-      return this.get(url);
+      return this.http.get(url);
     },
 
-    nextEvents: (id: string) => this.get('/contracts/' + id + '/next-events'),
+    nextEvents: (id: string) => this.http.get('/contracts/' + id + '/next-events'),
 
     instantiate: (instantiateInput: InstantiationInput) =>
-      this.post('/contracts', instantiateInput),
+      this.http.post('/contracts', instantiateInput),
 
     applyEvent: (id: string, event: Event, tag?: Tag) => {
-      if (tag) return this.post('/contracts/' + id + '/' + tag + '/events', event);
-      return this.post('/contracts/' + id + '/events', event);
+      if (tag) return this.http.post('/contracts/' + id + '/' + tag + '/events', event);
+      return this.http.post('/contracts/' + id + '/events', event);
     },
 
-    report: (expressionInput: ExpressionInput) => this.post('/contracts/report', expressionInput),
+    report: (expressionInput: ExpressionInput) =>
+      this.http.post('/contracts/report', expressionInput),
 
     reportOnContract: (id: string, expressionInput: ExpressionInput) =>
-      this.post('/contracts/' + id + '/report', expressionInput),
+      this.http.post('/contracts/' + id + '/report', expressionInput),
   };
 
   declarations: DeclarationsApi = {
-    getAll: () => this.get('/declarations'),
+    getAll: () => this.http.get('/declarations'),
 
-    get: (id: string) => this.get('/declarations/' + id),
+    get: (id: string) => this.http.get('/declarations/' + id),
 
-    add: (i: DeclarationInput) => this.post('/declarations', i),
+    add: (i: DeclarationInput) => this.http.post('/declarations', i),
 
-    ontology: (id: string) => this.get('/declarations/' + id + '/ontology'),
+    ontology: (id: string) => this.http.get('/declarations/' + id + '/ontology'),
   };
 
   csl: CslApi = {
-    check: (i: ExpressionInput) => this.post('/csl/check', i),
+    check: (i: ExpressionInput) => this.http.post('/csl/check', i),
 
     checkExpression: (i: ExpressionInput, id?: string) => {
-      if (id) return this.post('/csl/check-expression/' + id, i);
-      return this.post('/csl/check-expression', i);
+      if (id) return this.http.post('/csl/check-expression/' + id, i);
+      return this.http.post('/csl/check-expression', i);
     },
 
   };
 
   info: InfoApi = {
-    get: () => this.get('/node-info'),
+    get: () => this.http.get('/node-info'),
   };
 }
 

--- a/lib/DeonWebSocketClient.ts
+++ b/lib/DeonWebSocketClient.ts
@@ -1,0 +1,81 @@
+import { ContractUpdate } from './DeonApi';
+
+/**
+ * Constructs a Deon WebSocket client, and returns object wrapping the connection,
+ * which exposes a "reconnect" method that can be used to attempt to reestablish
+ * a connection, and a "close" method for closing the connection.
+ *
+ * @param host - current hostname, e.g., `window.location.host`.
+ * @param protocol - protocol string (`"ws"` or `"wss"`)
+ * @param wsCtor - a constructor for an object that implements the `WebSocket` interface
+ * @param messageHandler - function to call when message is received through the WebSocket.
+ * @param offlineHook - function to call when connection fails.
+ */
+class DeonWebSocketClient {
+  constructor(
+    host: string,
+    protocol : string,
+    wsCtor: (url : string) => WebSocket,
+    messageHandler: (msg: ContractUpdate) => void,
+    offlineHook: () => void,
+  ) {
+    this.url = `${protocol}://${host}/contractUpdates`;
+    this.wsCtor = wsCtor;
+    this.messageHandler = messageHandler;
+    this.offlineHook = offlineHook;
+    this.start();
+  }
+
+  private wsCtor : (url : string) => WebSocket;
+  private messageHandler: (msg: ContractUpdate) => void;
+  private offlineHook: () => void;
+
+  private url: string;
+
+  private ws: WebSocket | undefined;
+
+  close(): void {
+    if (this.ws !== undefined) {
+      this.ws.close();
+    }
+  }
+
+  start(): void {
+    this.close();
+    this.ws = this.wsCtor(this.url);
+    this.ws.onmessage = e => this.messageHandler(JSON.parse(e.data));
+    this.ws.onerror = _ => this.offlineHook();
+    this.ws.onclose = _ => this.offlineHook();
+    this.ws.onopen = (e) => {
+      if (e.type === 'close') {
+        this.offlineHook();
+      }
+    };
+  }
+
+  reconnect(): void {
+    if (this.ws === undefined || this.ws.readyState === this.ws.CLOSED) {
+      this.start();
+    }
+  }
+}
+
+interface WebSocket {
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null;
+  onerror: ((this: WebSocket, ev: Event) => any) | null;
+  onmessage: ((this: WebSocket, ev: MessageEvent) => any) | null;
+  onopen: ((this: WebSocket, ev: Event) => any) | null;
+  readonly readyState: number;
+  close(code?: number, reason?: string): void;
+  readonly CLOSED: number;
+}
+
+interface CloseEvent {}
+interface MessageEvent {
+  readonly data: any;
+}
+interface Event {
+  readonly type: string;
+}
+
+export { DeonWebSocketClient };

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -1,0 +1,54 @@
+import { RestResponse } from './DeonApi';
+
+export type Response = any;
+export type RequestInit = any;
+export type Request = any;
+
+export class HttpClient {
+  private fetch: (url: string | Request, init?: RequestInit) => Promise<Response>;
+  private hook: (r: Response) => PromiseLike<Response> | Response;
+  private serverUrl: string;
+
+  constructor(
+    fetch : (url: string | Request, init?: RequestInit) => Promise<Response>,
+    hook: (r: Response) => PromiseLike<Response> | Response,
+    serverUrl: string,
+  ) {
+    this.fetch = fetch;
+    this.hook = hook;
+    this.serverUrl = serverUrl;
+  }
+
+  get = <TOk, TErr>(url: string): Promise<RestResponse<TOk, TErr>> =>
+    this.fetchRest(this.serverUrl + url)
+
+  post = <TOk, TErr>(url: string, data: object): Promise<RestResponse<TOk, TErr>> =>
+    this.fetchRest(this.serverUrl + url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+
+  private fetchRest = <TOk, TErr>(
+    url: string,
+    data?: RequestInit,
+  ): Promise<RestResponse<TOk, TErr>> =>
+    this.fetch(url, data).then(this.hook).then(r => this.toRestResponse<TOk, TErr>(r))
+
+  private toRestResponse = async <TOk, TErr>(r: Response): Promise<RestResponse<TOk, TErr>> => {
+    const hasData = r.status !== 204 && r.headers.get('content-length') !== '0';
+
+    if (r.ok) {
+      if (hasData) {
+        const data: TOk = await r.json();
+        return { data, ok: true, statusCode: r.status };
+      }
+      return { ok: true, statusCode: r.status };
+    }
+    if (hasData) {
+      const data: TErr = await r.json();
+      return { data, ok: false, statusCode: r.status };
+    }
+    return { ok: false, statusCode: r.status };
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './DeonApi';
 export * from './DeonData';
 export * from './DeonRestClient';
+export * from './DeonWebSocketClient';
 export * from './valueToJson';

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.2.tgz",
-      "integrity": "sha512-tfg9rh2qQhBW6SBqpvfqTgU6lHWGhQURoTrn7NeDF+CEkO9JGYbkzU23EXu6p3bnvDxLeeSX8ohAA23urvWeNw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.3.tgz",
+      "integrity": "sha512-C1wVVr7xhKu6c3Mb27dFzNYR05qvHwgtpN+JOYTGc1pKA7dCEDDYpscn7kul+bCUwa3NoGDbzI1pdznSOa397w==",
       "dev": true
     },
     "ansi-regex": {
@@ -514,12 +514,13 @@
       }
     },
     "ts-node": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.1.1.tgz",
-      "integrity": "sha512-79FnymLGDBd/nXoiak1L6w6fd9Zz9Ge/x8/Aglaeh31KkqRLDzbfT1vBGlO5dqc76WzufTlW4IYl7e01CVUF5A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-6.1.2.tgz",
+      "integrity": "sha512-FS0pXZK0RAHFn+aq7iuWx4FPHiyUMM6p6DgKCl44c5tZKad2aUnwDH09XhsUmR0ncV2gd+ND1EV/Br5HpTxGJg==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
         "minimist": "^1.2.0",


### PR DESCRIPTION
Instead of depending on bespoke `get` and `post` methods, as provided by `web-api-client` and `node-api-client` packages, this PR changes the dependency to a `fetch` function.

So a web/browser user would inject `(url, data) => fetch(url, data)`, while a nodejs user could inject the fetch function from the `node-fetch` package.

In order to make the package standalone, the websocket client from `web-api-client` is also included in a version that takes a websocket constructor as a dependency.  A web user can inject `(url) => new WebSocket(url)`.

A major version bump is required.