### PR TITLE
Remove `RestResponse` wrapper around return values

### DIFF
--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -11,44 +11,32 @@ interface DeonApi {
 }
 
 interface ContractsApi {
-  getAll(): Promise<RestResponse<D.Contract[], void>>;
-  get(id: string): Promise<RestResponse<D.Contract, NotFoundError>>;
-  tree(id: string): Promise<RestResponse<D.ContractTree, NotFoundError>>;
-  src(id: string, simplified: boolean): Promise<RestResponse<D.ResidualSource, NotFoundError>>;
-  nextEvents(id: string): Promise<RestResponse<D.EventPredicate[], NotFoundError>>;
-  instantiate(i: D.InstantiationInput):
-    Promise<RestResponse<D.InstantiationOutput, BadRequestError>>;
-  applyEvent(id: string, event: D.Event, tag?: D.Tag):
-    Promise<RestResponse<D.Tag, BadRequestError | NotFoundError>>;
-  report(i: D.ExpressionInput): Promise<RestResponse<D.Value, BadRequestError>>;
-  reportOnContract(id: string, i: D.ExpressionInput):
-    Promise<RestResponse<D.Value, BadRequestError | NotFoundError>>;
+  getAll(): Promise<D.Contract[]>;
+  get(id: string): Promise<D.Contract>;
+  tree(id: string): Promise<D.ContractTree>;
+  src(id: string, simplified: boolean): Promise<D.ResidualSource>;
+  nextEvents(id: string): Promise<D.EventPredicate[]>;
+  instantiate(i: D.InstantiationInput): Promise<D.InstantiationOutput>;
+  applyEvent(id: string, event: D.Event, tag?: D.Tag): Promise<D.Tag | void>;
+  report(i: D.ExpressionInput): Promise<D.Value>;
+  reportOnContract(id: string, i: D.ExpressionInput): Promise<D.Value>;
 }
 
 interface DeclarationsApi {
-  getAll(): Promise<RestResponse<D.Declaration[], void>>;
-  get(id: string): Promise<RestResponse<D.Declaration, NotFoundError>>;
-  add(declarationInput: D.DeclarationInput):
-    Promise<RestResponse<D.DeclarationOutput, BadRequestError>>;
-  ontology(id: string): Promise<RestResponse<D.Ontology, NotFoundError>>;
+  getAll(): Promise<D.Declaration[]>;
+  get(id: string): Promise<D.Declaration>;
+  add(declarationInput: D.DeclarationInput): Promise<D.DeclarationOutput>;
+  ontology(id: string): Promise<D.Ontology>;
 }
 
 interface CslApi {
-  check(i: D.ExpressionInput): Promise<RestResponse<void, CheckErrors[]>>;
-  checkExpression(i: D.ExpressionInput, id?: string): Promise<RestResponse<void, CheckErrors[]>>;
+  check(i: D.ExpressionInput): Promise<CheckErrors[]>;
+  checkExpression(i: D.ExpressionInput, id?: string): Promise<CheckErrors[]>;
 }
 
 interface InfoApi {
-  get(): Promise<RestResponse<D.NodeInfoOutput, void>>;
+  get(): Promise<D.NodeInfoOutput>;
 }
-
-/**
- * Represents a response from a webserver.
- * "ok" will be true iff the status code is in the range 200-299.
- */
-type RestResponse<TOk, TFail>
-  = { ok: true, statusCode: number, data?: TOk }
-  | { ok: false, statusCode: number, data?: TFail };
 
 /**
  * WebSocket message format
@@ -65,8 +53,17 @@ export type BatchItemUpdate
   | { type: 'AddEventFail', ref: string, error: string };
 
 /* Error types */
-export interface NotFoundError { message: string; }
-export interface BadRequestError { message: string; }
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 
 type CheckErrors
   = { class: 'ParseCheckErrors', parseErrors: ParseError[] }
@@ -89,5 +86,5 @@ interface Position {
 
 export {
   DeonApi, ContractsApi, DeclarationsApi, CslApi, InfoApi,
-  ContractUpdate, RestResponse, CheckErrors, ParseError, GeneralTypingError, Position,
+  ContractUpdate, CheckErrors, ParseError, GeneralTypingError, Position,
 };

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -1,5 +1,3 @@
-import { RestResponse } from './DeonApi';
-
 export type Response = any;
 export type RequestInit = any;
 export type Request = any;
@@ -19,36 +17,12 @@ export class HttpClient {
     this.serverUrl = serverUrl;
   }
 
-  get = <TOk, TErr>(url: string): Promise<RestResponse<TOk, TErr>> =>
-    this.fetchRest(this.serverUrl + url)
+  get = (url: string): Promise<Response> => this.fetch(this.serverUrl + url).then(this.hook);
 
-  post = <TOk, TErr>(url: string, data: object): Promise<RestResponse<TOk, TErr>> =>
-    this.fetchRest(this.serverUrl + url, {
+  post = (url: string, data: object): Promise<Response> =>
+    this.fetch(this.serverUrl + url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
-    })
-
-  private fetchRest = <TOk, TErr>(
-    url: string,
-    data?: RequestInit,
-  ): Promise<RestResponse<TOk, TErr>> =>
-    this.fetch(url, data).then(this.hook).then(r => this.toRestResponse<TOk, TErr>(r))
-
-  private toRestResponse = async <TOk, TErr>(r: Response): Promise<RestResponse<TOk, TErr>> => {
-    const hasData = r.status !== 204 && r.headers.get('content-length') !== '0';
-
-    if (r.ok) {
-      if (hasData) {
-        const data: TOk = await r.json();
-        return { data, ok: true, statusCode: r.status };
-      }
-      return { ok: true, statusCode: r.status };
-    }
-    if (hasData) {
-      const data: TErr = await r.json();
-      return { data, ok: false, statusCode: r.status };
-    }
-    return { ok: false, statusCode: r.status };
-  }
+    }).then(this.hook)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -538,9 +538,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
-      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tslint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "REST client for Deon Digital CSL service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR simplifies the interface by removing the `RestResponse<T,U>` wrapper around the return types.

If a HTTP call fails, then an exception will be thrown.

This should make the interface more composable.

### Example ###

Before:
```typescript
  const totalNumberOfEvents = async (): Promise<number> => {
    const contractsResponse = await client.contracts.getAll();
    if (!contractsResponse.ok) throw new Error('something went wrong');
    const eventLengthsAsync = contractsResponse.data.map(async ({ id }) => {
      const response = await client.contracts.reportOnContract(id, { csl: 'List::length events' });
      if (!response.ok) throw new Error('something went wrong');
      return response.data as IntValue;
    });
    return (await Promise.all(eventLengthsAsync)).reduce((m, { i }) => m + i, 0);    
  }
```

After:
```typescript
  const totalNumberOfEvents = async (): Promise<number> => {
    const eventLengthsAsync = (await client.contracts.getAll()).map(async ({ id }) =>
      await client.contracts.reportOnContract(
        id,
        { csl: 'List::length events' },
      ) as IntValue);
    return (await Promise.all(eventLengthsAsync)).reduce((m, { i }) => m + i, 0);
  };
```
