### PR TITLE
Fix broken exception control flow

### DIFF
--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -53,15 +53,23 @@ export type BatchItemUpdate
   | { type: 'AddEventFail', ref: string, error: string };
 
 /* Error types */
-export class NotFoundError extends Error {
-  constructor(message: string) {
+export class ResponseError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
     super(message);
+    this.status = status;
   }
 }
 
-export class BadRequestError extends Error {
+export class NotFoundError extends ResponseError {
   constructor(message: string) {
-    super(message);
+    super(404, message);
+  }
+}
+
+export class BadRequestError extends ResponseError {
+  constructor(message: string) {
+    super(400, message);
   }
 }
 

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -6,26 +6,29 @@ import {
   InfoApi,
   NotFoundError,
   BadRequestError,
+  ResponseError,
 } from './DeonApi';
 import { InstantiationInput, ExpressionInput, DeclarationInput, Event, Tag } from './DeonData';
 import { HttpClient, Response } from './HttpClient';
 
-const throwIfNotFound = async (r: Response) => {
-  const data = await getData(r);
+const throwIfNotFound = (r: Response, data: any) => {
   if (r.status === 404 && data && data.message) {
     throw new NotFoundError(data.message);
   }
 };
 
-const throwIfBadRequest = async (r: Response) => {
-  const data = await getData(r);
+const throwIfBadRequest = (r: Response, data: any) => {
   if (r.status === 400 && data && data.message) {
     throw new BadRequestError(data.message);
   }
 };
 
-const throwUnexpected = (r: Response): never => {
-  throw new Error('Unexpected error: ' + JSON.stringify(r));
+const throwUnexpected = (r: Response, data: any): never => {
+  throw new ResponseError(
+    r.status,
+    `Unexpected error. Status: ${r.status} ${r.statusText}. `
+      + `Data: ${JSON.stringify(data)}`,
+  );
 };
 
 const getData = async (r: Response): Promise<any> => {
@@ -35,35 +38,39 @@ const getData = async (r: Response): Promise<any> => {
 };
 
 const noKnownExceptions = async (r: Response) => {
+  const data = await getData(r);
   if (r.ok) {
-    return getData(r);
+    return data;
   }
-  throwUnexpected(r);
+  throwUnexpected(r, data);
 };
 
 const possiblyNotFound = async (r: Response) => {
+  const data = await getData(r);
   if (r.ok) {
-    return getData(r);
+    return data;
   }
-  throwIfNotFound(r);
-  throwUnexpected(r);
+  throwIfNotFound(r, data);
+  throwUnexpected(r, data);
 };
 
 const possiblyBadRequest = async (r: Response) => {
+  const data = await getData(r);
   if (r.ok) {
-    return getData(r);
+    return data;
   }
-  throwIfBadRequest(r);
-  throwUnexpected(r);
+  throwIfBadRequest(r, data);
+  throwUnexpected(r, data);
 };
 
 const possiblyBadRequestOrNotFound = async (r: Response) => {
+  const data = await getData(r);
   if (r.ok) {
-    return getData(r);
+    return data;
   }
-  throwIfBadRequest(r);
-  throwIfNotFound(r);
-  throwUnexpected(r);
+  throwIfBadRequest(r, data);
+  throwIfNotFound(r, data);
+  throwUnexpected(r, data);
 };
 
 /**


### PR DESCRIPTION
`throwIfNotFound` and `throwIfBadRequest` were async, and since they were not `await`ed when called, it could result in multiple exceptions thrown for one request.

For example:

```javascript
  throwIfBadRequest(r);
  throwUnexpected(r);
```

The first line would spin off a new promise which would later be rejected and result in an `UnhandledPromiseRejectionWarning` being thrown.  This happens asynchronously, so the second line would also be evaluated, and would throw an error (synchronously).
