### PR TITLE
Support for `SelfContractId` instantiation argument

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,10 @@
 
 ## Changelog
 
+### Unpublished
+
+* Add support for `SelfContractId` instantiation argument, which resolves to the id of the contract that is being instantiated.
+
 ### [3.2.0] - 2018-08-30
 
 * Expose ISO8601 duration parsing functionality.

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -13,7 +13,7 @@ export interface DeclarationOutput {
 export interface InstantiationInput {
   declarationId: string;
   name: string;
-  declarationExpressionArguments: Value[];
+  declarationExpressionArguments: InstantiationArgument[];
   entryPoint: QualifiedName;
   peers: string[];
 }
@@ -177,6 +177,17 @@ export interface AgentValue {
   identifier: string;
   boundName: QualifiedName;
 }
+
+/* Instantiation arguments */
+export type InstantiationArgument
+  = Value
+  | SelfContractId;
+
+export interface SelfContractId {
+  class: 'SelfContractId';
+}
+
+export const selfContractId: SelfContractId = { class: 'SelfContractId' };
 
 /* Contract AST tree */
 export type ContractTree


### PR DESCRIPTION
The special `SelfContractId` instantiation argument value is resolved to the instantiated contract's own id.