### PR TITLE
Move dependency to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
       },
       "dependencies": {
         "tsutils": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.1.tgz",
-          "integrity": "sha512-g9kwRQRpVDhjS3qfrDsnYv7QkBtsNRm1Ln5539hq9Y2ysndnlaWf8+3zTdaa1YB5ko7dpV9XATlP0KmYPsLc+Q==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.2.tgz",
+          "integrity": "sha512-qIlklNuI/1Dzfm+G+kJV5gg3gimZIX5haYtIVQe7qGyKd7eu8T1t1DY6pz4Sc2CGXAj9s1izycctm9Zfl9sRuQ==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"
@@ -53,6 +53,7 @@
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.3.tgz",
       "integrity": "sha512-auZ3vEo3UW8tZc9NhF0MTnutKlf+YhsfC3+dwskFcil/EoqqZF60pGuJ2v2Ae1OJTUp3DJnjOJMqrpkmKB904w==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -67,6 +68,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha512-wf/Iecb9HDfbfnZfrk49FdRFlEb+2ZRFDVjmiRZFutQVeUMnEpDelvNCNeck85FD5GkxsBc8kJR41/wgZWfF6g==",
+      "dev": true,
       "requires": {
         "@types/bn.js": "*"
       }
@@ -78,9 +80,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
-      "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w=="
+      "version": "10.12.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -346,9 +349,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.0.tgz",
-      "integrity": "sha512-cF41L/f/7nXpSwMMHMY0FIurpTPZq/eHwJdeh2+0kKYhL9eD7RqsgMujd3qdqvWdjGIHjwvd/iEMTNECl2EhzA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.1.tgz",
+      "integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg==",
       "dev": true
     },
     "get-func-name": {
@@ -393,9 +396,9 @@
       "dev": true
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -569,12 +572,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "semver": {
@@ -601,7 +604,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -713,9 +716,9 @@
           "dev": true
         },
         "tsutils": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.1.tgz",
-          "integrity": "sha512-g9kwRQRpVDhjS3qfrDsnYv7QkBtsNRm1Ln5539hq9Y2ysndnlaWf8+3zTdaa1YB5ko7dpV9XATlP0KmYPsLc+Q==",
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.5.2.tgz",
+          "integrity": "sha512-qIlklNuI/1Dzfm+G+kJV5gg3gimZIX5haYtIVQe7qGyKd7eu8T1t1DY6pz4Sc2CGXAj9s1izycctm9Zfl9sRuQ==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/base64-js": "^1.2.5",
     "@types/chai": "^4.1.3",
+    "@types/elliptic": "^6.4.0",
     "@types/mocha": "^5.2.0",
     "chai": "^4.1.2",
     "mocha": "^5.1.1",
@@ -33,7 +34,6 @@
   },
   "dependencies": {
     "@lapo/asn1js": "^1.0.2",
-    "@types/elliptic": "^6.4.0",
     "base64-js": "^1.3.0",
     "elliptic": "^6.4.1",
     "js-sha3": "^0.8.0",


### PR DESCRIPTION
A dependency that was only used for building the package was placed in `dependencies`.  It should be in `devDependencies` so that users of the package will avoid having them in their dependency tree unnecessarily.