### PR TITLE
hide elliptic defs from exported ts defs

### DIFF
--- a/lib/ECDSA.ts
+++ b/lib/ECDSA.ts
@@ -97,7 +97,19 @@ function decodeASN1PrivatePem(pem: string): Buffer | string {
   }
 }
 
-export function decodePublicKey(pem: string): Elliptic.ec.KeyPair | string {
+interface ECPrivateKey {
+  sign(input: string): Signature;
+}
+
+interface ECPublicKey {
+  verify(hashed: string, der: any): string | boolean;
+}
+
+interface Signature {
+  toDER(): any;
+}
+
+export function decodePublicKey(pem: string): ECPublicKey | string {
   const buffer = decodeASN1PublicPem(pem);
   if (typeof buffer === 'string') {
     return buffer;
@@ -109,7 +121,7 @@ export function decodePublicKey(pem: string): Elliptic.ec.KeyPair | string {
   }
 }
 
-export function decodePrivateKey(pem: string): Elliptic.ec.KeyPair | string {
+export function decodePrivateKey(pem: string): ECPrivateKey | string {
   const buffer = decodeASN1PrivatePem(pem);
   if (typeof buffer === 'string') {
     return buffer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,9 +80,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
-      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -131,7 +131,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -657,9 +657,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
+      "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",


### PR DESCRIPTION
If the API from `ECDSA` exports types from `@types/elliptic` it requires us to put `@types/elliptic` in `dependencies` instead of `devDependencies` where it really belongs. Alternatively, the users of `api-client` must explicitly install `@types/elliptic` as well, which is less than ideal. Luckily, we can hide these types using structural interfaces <3.