### PR TITLE
HttpClient hook should also handle rejected promises

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,10 @@
 
 ## Changelog
 
+### Unreleased
+
+* API change for `DeonRestClient` constructor: hook now has type `(r: Promise<Response>) => Promise<Response>` and can catch rejected promises.
+
 ### [7.0.0] - 2019-01-03
 
 * `AgentValue` now has a proper `AgentIdentifier` instead of a string.

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 ## Changelog
 
-### Unreleased
+### [8.0.0] - Unreleased
 
 * API change for `DeonRestClient` constructor: hook now has type `(r: Promise<Response>) => Promise<Response>` and can catch rejected promises.
 

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -113,7 +113,7 @@ class DeonRestClient implements DeonApi {
   static create = (
     fetch: (url: any, init: any) => Promise<Response>,
     serverUrl: string = '',
-    hook: (r: Response) => PromiseLike<Response> | Response = r => r,
+    hook: (r: Promise<Response>) => Promise<Response> = r => r,
   ) => new DeonRestClient(new HttpClient(fetch, hook, serverUrl))
 
   contracts: ContractsApi = {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -5,16 +5,16 @@ export type Request = any;
 export class HttpClient {
   constructor(
     private fetch : (url: string | Request, init?: RequestInit) => Promise<Response>,
-    private hook: (r: Response) => PromiseLike<Response> | Response,
+    private hook: (r: Promise<Response>) => Promise<Response>,
     private serverUrl: string,
   ) {}
 
-  get = (url: string): Promise<Response> => this.fetch(this.serverUrl + url).then(this.hook);
+  get = (url: string): Promise<Response> => this.hook(this.fetch(this.serverUrl + url));
 
   post = (url: string, data: object): Promise<Response> =>
-    this.fetch(this.serverUrl + url, {
+    this.hook(this.fetch(this.serverUrl + url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
-    }).then(this.hook)
+    }))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -186,7 +186,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "REST client for Deon Digital CSL service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The optional hook for `DeonRestClient` could only be used to intercept resolved promises, not rejected promises (i.e. when there are network problems).  With this PR the hook will also receive the rejected promises.