### PR TITLE
Bump patch to `10.1.1` because of NPM publishing...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deondigital/api-client",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "REST client for Deon Digital CSL service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I can't seem to publish a new `api-client@10.1.0` to NPM even though the old erroneus one has been removed...