### PR TITLE
Rename ExternalObject.{Agent,Contract}->{StringAgent,StringContract}

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,9 +4,9 @@
 
 ### Unreleased
 
-* Remove `Pseudo` and replace it with `ExternalObject` which is equivalent except that it doesn't require the specification of "bound names" which was an ill-defined concept.
+* Remove `Pseudo` and replace it with `ExternalObject` which is equivalent except that it doesn't require the specification of "bound names".
 * Change `ContractId` to `Contract` everywhere for consistency with `Agent`.
-* Remove `ContractIdentifier` and `AgentIdentifier`. Where type safety is wanted, use `ExternalObject.Contract` and `ExternalObject.Agent`.
+* Remove `ContractIdentifier` and `AgentIdentifier`. Where type safety is wanted, use `ExternalObject.StringContract` and `ExternalObject.StringAgent`.
 
 ### [11.0.0] - 2019-09-27
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -114,8 +114,8 @@ export type Value =
   | TupleValue
   | ExternalObjectValue<any>;
 
-export type ContractValue = ExternalObjectValue<ExternalObject.Contract>;
-export type AgentValue = ExternalObjectValue<ExternalObject.Agent>;
+export type ContractValue = ExternalObjectValue<ExternalObject.StringContract>;
+export type AgentValue = ExternalObjectValue<ExternalObject.StringAgent>;
 export type PublicKeyValue = ExternalObjectValue<ExternalObject.PublicKey>;
 export type SignedValue = ExternalObjectValue<ExternalObject.SignedValue>;
 

--- a/lib/ExternalObject.ts
+++ b/lib/ExternalObject.ts
@@ -8,12 +8,12 @@ import * as SignedData from './Signed';
 
 export namespace ExternalObject {
 
-  export interface Agent {
-    tag: 'Agent';
+  export interface StringAgent {
+    tag: 'StringAgent';
     agentIdentifier: string;
   }
-  export const mkAgent = (agentIdentifier: string): ExternalObject.Agent =>
-    ({ agentIdentifier, tag: 'Agent' });
+  export const mkAgent = (agentIdentifier: string): ExternalObject.StringAgent =>
+    ({ agentIdentifier, tag: 'StringAgent' });
 
   export interface PublicKey {
     tag: 'PublicKey';
@@ -30,16 +30,16 @@ export namespace ExternalObject {
     (signedValue: SignedData.Signed<Value>): ExternalObject.SignedValue =>
       ({ signedValue, tag: 'SignedValue' });
 
-  export interface Contract {
-    tag: 'Contract';
+  export interface StringContract {
+    tag: 'StringContract';
     contractIdentifier: string;
   }
-  export const mkContract = (contractIdentifier: string): ExternalObject.Contract =>
-    ({ contractIdentifier, tag: 'Contract' });
+  export const mkContract = (contractIdentifier: string): ExternalObject.StringContract =>
+    ({ contractIdentifier, tag: 'StringContract' });
 }
 
 export type ExternalObject
-  = ExternalObject.Agent
-  | ExternalObject.Contract
+  = ExternalObject.StringAgent
+  | ExternalObject.StringContract
   | ExternalObject.PublicKey
   | ExternalObject.SignedValue;

--- a/test/valueToJson.spec.ts
+++ b/test/valueToJson.spec.ts
@@ -129,7 +129,7 @@ describe('Fully typed to JSON typed', () => {
   it('works on Agents', () => {
     const a: D.AgentValue = {
       class: 'ExternalObjectValue',
-      externalObject: { tag: 'Agent', agentIdentifier: 'foo' },
+      externalObject: { tag: 'StringAgent', agentIdentifier: 'foo' },
     };
     expect(valueToJson(a)).to.deep.equal({
       externalObject: { agentIdentifier: 'foo' },
@@ -138,7 +138,7 @@ describe('Fully typed to JSON typed', () => {
   it('works on ContractIds', () => {
     const c: D.ContractValue = {
       class: 'ExternalObjectValue',
-      externalObject: { tag: 'Contract', contractIdentifier: 'foo' },
+      externalObject: { tag: 'StringContract', contractIdentifier: 'foo' },
     };
     expect(valueToJson(c)).to.deep.equal({
       externalObject: { contractIdentifier: 'foo' },


### PR DESCRIPTION
Also update the changelog and reword the entry on the removal of `Pseudo`.