### PR TITLE
Always return tag from event application

### DIFF
--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -24,7 +24,7 @@ interface ContractsApi {
     id: string | D.ContractValue,
     event: D.Event,
     tag?: D.Tag,
-  ): Promise<D.Tag | void>;
+  ): Promise<D.Tag>;
   getEvents(id: string | D.ContractValue): Promise<D.Value[]>;
 }
 


### PR DESCRIPTION
The returned tag was previously optional and depended on the input containing a tag.

Related to https://gitlab.deondigital.com/deon/development/deon-dsl/merge_requests/1622