### PR TITLE
Change `Duration` representation to be a `class`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,10 @@
 
 ## Changelog
 
+### Unreleased
+
+* The `Duration` type is now a `class` with `equals` and `hashCode` methods.  This makes it possible to use it with the containers in `immutable-js`.
+
 ### [14.1.2] - 2020-03-27
 
 * Aligned error codes with current version of the API webservice.

--- a/lib/ISO8601Duration.ts
+++ b/lib/ISO8601Duration.ts
@@ -53,7 +53,7 @@ const numbers = '\\d+(?:[\\.,]\\d{0,3})?';
 const datePattern = `(${numbers}D)?`;
 const timePattern = `T(${numbers}H)?(${numbers}M)?(${numbers}S)?`;
 
-const iso8601 = `P(?:${datePattern}(?:${timePattern})?)`;
+const iso8601 = `^P(?:${datePattern}(?:${timePattern})?)$`;
 
 /**
  * The ISO8601 regex for matching / testing durations

--- a/lib/ISO8601Duration.ts
+++ b/lib/ISO8601Duration.ts
@@ -17,7 +17,7 @@ export class Duration {
     this.days = days;
     this.hours = hours;
     this.minutes = minutes;
-    this.seconds = seconds; // TODO Throw exception if decimal count > 3?
+    this.seconds = seconds;
   }
 
   static construct(r: { days: number; hours: number; minutes: number; seconds: number }) {
@@ -62,10 +62,7 @@ export const pattern = new RegExp(iso8601);
 
 /**
  * Parse PnYnMnDTnHnMnS format to object.  Note that the 'seconds' component only
- * allows for a precision of up to three decimal places.  If you supply a string
- * that contains a 'seconds' component with a higher precision it will be parsed as
- * 0 seconds.  I.e., 'P1DT2H33M15.123S' will be parsed as expected but 'P1DT2H33M15.1234S'
- * will be parsed as if it was the string 'P1DT2H33M0S'.
+ * allows for a precision of up to three decimal places.
  *
  * @param  durationString - PnYnMnDTnHnMnS formatted string
  * @return With a property for each part of the pattern
@@ -105,7 +102,7 @@ export const toSeconds = (duration: Duration): number => {
 
 /**
  * Takes a Duration object and turns into an ISO8601 duration string, e.g.
- * P1DT2H33M15.0001S (1 day, 2 hours, 33 minutes, 15.0001 seconds)
+ * P1DT2H33M15.001S (1 day, 2 hours, 33 minutes, 15.001 seconds)
  * @param d
  */
 export const durationToISOString = (d: Duration): string => {

--- a/lib/ISO8601Duration.ts
+++ b/lib/ISO8601Duration.ts
@@ -17,7 +17,7 @@ export class Duration {
     this.days = days;
     this.hours = hours;
     this.minutes = minutes;
-    this.seconds = seconds;
+    this.seconds = seconds; // TODO Throw exception if decimal count > 3?
   }
 
   static construct(r: { days: number; hours: number; minutes: number; seconds: number }) {

--- a/test/DeonData.spec.ts
+++ b/test/DeonData.spec.ts
@@ -162,8 +162,11 @@ describe('Duration', () => {
     const prefixStr = `abc${durStr}`;
     const suffixStr = `${durStr}def`;
     const presuffixStr = `abc${durStr}def`;
+    const tooManyDecimalPlaces = 'P1DT2H33M15.1234S';
     expect(parse(prefixStr)).to.be.undefined;
     expect(parse(suffixStr)).to.be.undefined;
     expect(parse(presuffixStr)).to.be.undefined;
-  })
+    expect(parse(tooManyDecimalPlaces)).to.be.undefined;
+  });
+
 });

--- a/test/DeonData.spec.ts
+++ b/test/DeonData.spec.ts
@@ -158,4 +158,12 @@ describe('Duration', () => {
   it('Can render Duration as ISO8601 strings', () => {
     expect(durationToISOString(duration)).to.equal(durStr);
   });
+  it('Cannot parse duration strings with prefix/suffix', () => {
+    const prefixStr = `abc${durStr}`;
+    const suffixStr = `${durStr}def`;
+    const presuffixStr = `abc${durStr}def`;
+    expect(parse(prefixStr)).to.be.undefined;
+    expect(parse(suffixStr)).to.be.undefined;
+    expect(parse(presuffixStr)).to.be.undefined;
+  })
 });

--- a/test/DeonData.spec.ts
+++ b/test/DeonData.spec.ts
@@ -13,6 +13,7 @@ import {
   checkSignature,
 } from '../lib/Signed';
 import { ExternalObject } from '../lib/ExternalObject';
+import { parse, Duration, durationToISOString } from '../lib/ISO8601Duration';
 
 const id = <T>(x:T) => x;
 
@@ -143,5 +144,18 @@ mfQTPF+h5iOq9dC/P+BqQwKkVUkU+A==
     const pubk = (pubkVal.externalObject as ExternalObject.PublicKey).publicKey;
     const check = checkSignature(pubk, signed, id);
     expect(typeof check).to.equal('string');
+  });
+});
+
+describe('Duration', () => {
+  const durStr = 'P1DT2H33M15.123S';
+  const duration = Duration.construct({ days: 1, hours: 2, minutes: 33, seconds: 15.123 });
+  it('Can parse ISO8601 duration strings', () => {
+    const dur = parse(durStr);
+    expect(dur).to.not.be.undefined;
+    expect(dur).to.deep.equal(duration);
+  });
+  it('Can render Duration as ISO8601 strings', () => {
+    expect(durationToISOString(duration)).to.equal(durStr);
   });
 });


### PR DESCRIPTION
This allows us to put `.equals` and `.hashCode` methods on it, so it can be meaningfully used with `immutable-js` structures.