### PR TITLE
Add support for the reified data structures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 ### Unreleased
 
 * Added support for CSL's built-in `Set` type.
+* Added support for retrieving and working with residual contracts.
 
 ### [16.0.1] - 2020-05-28
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -965,7 +965,8 @@ export type AtomTerm
   | ATConstant
   | ATApp
   | ATTuple
-  | ATMap;
+  | ATMap
+  | ATSet;
 
 export interface ATWildcard {
   tag: 'Wildcard';
@@ -1002,4 +1003,9 @@ export interface ATTuple {
 export interface ATMap {
   tag: 'Map';
   entries: [AtomTerm, AtomTerm][];
+}
+
+export interface ATSet {
+  tag: 'Set';
+  entries: AtomTerm[];
 }

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -83,7 +83,7 @@ export interface EventPredicate {
   agent: ReifiedAgentMatcher;
   exp: ReifiedExp;
   env: ReifiedHeap;
-  entities: ExternalObject[];
+  entities: { [id: string] : ExternalObject };
   residualContract: ReifiedRuntimeContract;
 }
 
@@ -139,9 +139,47 @@ export interface ReifiedAtomHasEvent {
   event: number;
 }
 
+export type ReifiedConstant =
+  ReifiedCInt
+  | ReifiedCString
+  | ReifiedCFloat
+  | ReifiedCDateTime
+  | ReifiedCDuration
+  | ReifiedCQuote;
+
+export interface ReifiedCInt {
+  tag: 'Int';
+  value: number;
+}
+
+export interface ReifiedCString {
+  tag: 'String';
+  value: string;
+}
+
+export interface ReifiedCFloat {
+  tag: 'Float';
+  value: string;
+}
+
+export interface ReifiedCDateTime {
+  tag: 'DateTime';
+  instant: string;
+}
+
+export interface ReifiedCDuration {
+  tag: 'Duration';
+  duration: string;
+}
+
+export interface ReifiedCQuote {
+  tag: 'Quote';
+  symbol: number;
+}
+
 export type ReifiedValue =
   ReifiedConstructor
-  | ReifiedConstant
+  | ReifiedConstantValue
   | ReifiedRecord
   | ReifiedFunction
   | ReifiedList
@@ -154,7 +192,7 @@ export interface ReifiedConstructor {
   args: number[];
 }
 
-export interface ReifiedConstant {
+export interface ReifiedConstantValue {
   tag: 'Constant';
   const: number;
 }
@@ -329,7 +367,7 @@ export interface ReifiedAVar {
 export interface ReifiedARecord {
   tag: 'Record';
   name: QualifiedName;
-  fields: [string, number][];
+  fields:  { [id: string] : number };
 }
 export interface ReifiedAConstant {
   tag: 'Constant';
@@ -409,7 +447,7 @@ export interface ReifiedAnyAgent {
 }
 
 export interface ReifiedMatchAgent {
-  tag: 'ReifiedMatchAgent';
+  tag: 'MatchAgent';
   expression: number;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -184,7 +184,8 @@ export type ReifiedValue =
   | ReifiedFunction
   | ReifiedList
   | ReifiedTuple
-  | ReifiedMap;
+  | ReifiedMap
+  | ReifiedSet;
 
 export interface ReifiedConstructor {
   tag: 'Constructor';
@@ -222,6 +223,11 @@ export interface ReifiedTuple {
 export interface ReifiedMap {
   tag: 'Map';
   sortedEntries: [number, number][];
+}
+
+export interface ReifiedSet {
+  tag: 'Set';
+  sortedElements: [number];
 }
 
 export type ReifiedValueEnv = [QualifiedName, number][];
@@ -354,7 +360,8 @@ export type ReifiedAtomTerm =
   | ReifiedAConstant
   | ReifiedAApp
   | ReifiedATuple
-  | ReifiedAMap;
+  | ReifiedAMap
+  | ReifiedASet;
 
 export interface ReifiedAWildcard {
   tag: 'Wildcard';
@@ -385,6 +392,10 @@ export interface ReifiedATuple {
 export interface ReifiedAMap{
   tag: 'Map';
   entries: [number, number][];
+}
+export interface ReifiedASet{
+  tag: 'Set';
+  entries: [number];
 }
 
 export type ReifiedContract =

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -84,12 +84,12 @@ export interface EventPredicate {
   exp: ReifiedExp;
   env: ReifiedHeap;
   symbols: { [id: string] : ExternalObject };
-  residualContract: ReifiedRuntimeContract;
+  residualContract: ReifiedContract;
 }
 
 export interface ReifiedRuntimeContract {
   heap: ReifiedHeap;
-  entities: ExternalObject[];
+  symbols: { [id: string] : ExternalObject };
   runtimeContract: ReifiedContract;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -89,7 +89,7 @@ export interface EventPredicate {
 
 export interface ReifiedRuntimeContract {
   heap: ReifiedHeap;
-  symbols: { [id: string] : ExternalObject };
+  entities: ExternalObject[];
   runtimeContract: ReifiedContract;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -80,9 +80,10 @@ export type Tag = string;
 
 export interface EventPredicate {
   type: Type;
-  agent: AgentMatcher;
-  exp: Exp;
-  symbols: { [id: string] : ExternalObject };
+  agent: ReifiedAgentMatcher;
+  exp: ReifiedExp;
+  env: ReifiedHeap;
+  entities: ExternalObject[];
   residualContract: ReifiedRuntimeContract;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -139,8 +139,8 @@ export interface ReifiedAtomHasEvent {
   event: number;
 }
 
-export type ReifiedConstant =
-  ReifiedCInt
+export type ReifiedConstant
+  = ReifiedCInt
   | ReifiedCString
   | ReifiedCFloat
   | ReifiedCDateTime

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -83,7 +83,7 @@ export interface EventPredicate {
   agent: ReifiedAgentMatcher;
   exp: ReifiedExp;
   env: ReifiedHeap;
-  symbols: { [id: string] : ExternalObject };
+  entities: ExternalObject[];
   residualContract: ReifiedContract;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -384,7 +384,7 @@ export interface ReifiedATuple {
 }
 export interface ReifiedAMap{
   tag: 'Map';
-  nativeMap: [number, number][];
+  entries: [number, number][];
 }
 
 export type ReifiedContract =
@@ -990,5 +990,5 @@ export interface ATTuple {
 
 export interface ATMap {
   tag: 'Map';
-  nativeMap: [AtomTerm, AtomTerm][];
+  entries: [AtomTerm, AtomTerm][];
 }

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -83,7 +83,7 @@ export interface EventPredicate {
   agent: ReifiedAgentMatcher;
   exp: ReifiedExp;
   env: ReifiedHeap;
-  entities: { [id: string] : ExternalObject };
+  symbols: { [id: string] : ExternalObject };
   residualContract: ReifiedRuntimeContract;
 }
 

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -790,28 +790,28 @@ export interface CInt {
 }
 
 export interface CString {
-  tag: 'CInt';
+  tag: 'CString';
   value: string;
 }
 
 export interface CFloat {
-  tag: 'CInt';
+  tag: 'CFloat';
   value: string;
 }
 
 export interface CDateTime {
-  tag: 'CInt';
+  tag: 'CDateTime';
   value: string;
 }
 
 export interface CDuration {
-  tag: 'CInt';
+  tag: 'CDuration';
   value: string;
 }
 
 export interface CQuote {
   tag: 'CQuote';
-  value: ExternalObject;
+  value: string;
 }
 
 export interface PField {
@@ -922,7 +922,7 @@ export interface ERecord {
 export interface EProject {
   tag: 'EProject';
   expression: Exp;
-  field: Field;
+  field: string;
 }
 
 export interface EQuery {
@@ -953,7 +953,8 @@ export type AtomTerm
   | ATRecord
   | ATConstant
   | ATApp
-  | ATTuple;
+  | ATTuple
+  | ATMap;
 
 export interface ATWildcard {
   tag: 'Wildcard';
@@ -985,4 +986,9 @@ export interface ATApp {
 export interface ATTuple {
   tag: 'Tuple';
   elements: AtomTerm[];
+}
+
+export interface ATMap {
+  tag: 'Map';
+  nativeMap: [AtomTerm, AtomTerm][];
 }

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -83,6 +83,392 @@ export interface EventPredicate {
   agent: AgentMatcher;
   exp: Exp;
   symbols: { [id: string] : ExternalObject };
+  residualContract: ReifiedRuntimeContract;
+}
+
+export interface ReifiedRuntimeContract {
+  heap: ReifiedHeap;
+  entities: ExternalObject[];
+  runtimeContract: ReifiedContract;
+}
+
+export interface ReifiedHeap {
+  hValue: ReifiedValue[];
+  hConstant: ReifiedConstant[];
+  hExp: ReifiedExp[];
+  hValueEnv: ReifiedValueEnv[];
+  hAtomTerm: ReifiedAtomTerm[];
+  hContract: ReifiedContract[];
+  hCSLEnv: ReifiedCSLEnv[];
+  hContractEnv: ReifiedContractEnv[];
+  hTemplateEnv: ReifiedTemplateEnv[];
+  hSupertypeEnv: ReifiedSupertypeEnv[];
+  hRulesEnv: ReifiedRulesEnv[];
+  hAtom: ReifiedAtom[];
+}
+
+export interface ReifiedCSLEnv {
+  contractEnv: number;
+  templateEnv: number;
+  valueEnv: number;
+  supertypeEnv: number;
+  rulesEnv: number;
+}
+
+export type ReifiedAtom =
+  ReifiedAAtom
+  | ReifiedAtomRefl
+  | ReifiedAtomHasEvent;
+
+export interface ReifiedAAtom {
+  tag: 'Atom';
+  name: QualifiedName;
+  arguments: number[];
+}
+
+export interface ReifiedAtomRefl {
+  tag: 'Refl';
+  left: number;
+  right: number;
+}
+
+export interface ReifiedAtomHasEvent {
+  tag: 'HasEvent';
+  cid: number;
+  event: number;
+}
+
+export type ReifiedValue =
+  ReifiedConstructor
+  | ReifiedConstant
+  | ReifiedRecord
+  | ReifiedFunction
+  | ReifiedList
+  | ReifiedTuple
+  | ReifiedMap;
+
+export interface ReifiedConstructor {
+  tag: 'Constructor';
+  constructorName: QualifiedName;
+  args: number[];
+}
+
+export interface ReifiedConstant {
+  tag: 'Constant';
+  const: number;
+}
+
+export interface ReifiedRecord {
+  tag: 'Record';
+  name: QualifiedName;
+  fields: { [key: string]: number };
+}
+
+export interface ReifiedFunction {
+  tag: 'Function';
+  env: number;
+  exp: number;
+}
+
+export interface ReifiedList {
+  tag: 'List';
+  elements: number[];
+}
+
+export interface ReifiedTuple {
+  tag: 'Tuple';
+  values: number[];
+}
+
+export interface ReifiedMap {
+  tag: 'Map';
+  sortedEntries: [number, number][];
+}
+
+export type ReifiedValueEnv = [QualifiedName, number][];
+
+export type ReifiedRulesEnv = [RuleName, ReifiedRule[]][];
+
+export type ReifiedContractEnv = [QualifiedName, ReifiedContractClosure<number>][];
+
+export type ReifiedTemplateEnv = [QualifiedName, ReifiedContractClosure<ReifiedContractTemplate>][];
+
+export type ReifiedSupertypeEnv = [QualifiedName, QualifiedName][];
+
+export interface ReifiedContractClosure<A> {
+  closureEnv: number;
+  closureBody: A;
+}
+
+export interface ReifiedContractTemplate {
+  contractParameters: string[];
+  expressionParameters: string[];
+  contractBody: number;
+}
+
+export type RuleName =
+  AtomName
+  | ReflName
+  | HasEventName;
+
+export interface AtomName {
+  tag: 'AtomName';
+  name: QualifiedName;
+}
+
+export interface ReflName {
+  tag: 'ReflName';
+}
+
+export interface HasEventName {
+  tag: 'HasEventName';
+}
+
+export interface ReifiedRule {
+  tag: 'ReifiedRule';
+  head: number;
+  body: number[];
+}
+
+export type ReifiedExp =
+  ReifiedEConstant
+  | ReifiedEVar
+  | ReifiedEConstructor
+  | ReifiedETuple
+  | ReifiedELambda
+  | ReifiedEApp
+  | ReifiedEBuiltInApp
+  | RefifiedERecord
+  | ReifiedEProject
+  | ReifiedEQuery;
+
+export interface ReifiedEConstant {
+  tag: 'Constant';
+  constant: number;
+}
+
+export interface ReifiedEVar {
+  tag: 'Var';
+  qualifiedName: QualifiedName;
+}
+
+export interface ReifiedEConstructor {
+  tag: 'Constructor';
+  constructorName: QualifiedName;
+}
+
+export interface ReifiedETuple {
+  tag: 'Tuple';
+  values: number[];
+}
+
+export interface ReifiedELambda {
+  tag: 'Lambda';
+  cases: ReifiedCase[];
+}
+
+export interface ReifiedEApp {
+  tag: 'App';
+  expression: number;
+  arg: number;
+}
+
+export interface ReifiedEBuiltInApp {
+  tag: 'BuiltInApp';
+  builtInName: string;
+  args: number[];
+}
+
+export interface RefifiedERecord {
+  tag: 'Record';
+  type: Type;
+  fields: ReifiedField[];
+}
+
+export interface ReifiedEProject {
+  tag: 'Project';
+  expression: number;
+  field: string;
+}
+
+export interface ReifiedEQuery {
+  tag: 'Query';
+  ruleTerm: number;
+  ruleName: QualifiedName;
+  bodyExp: number;
+}
+
+export interface ReifiedCase {
+  pattern: Pattern;
+  expression: number;
+}
+
+export interface ReifiedField {
+  name: string;
+  expression: number;
+}
+
+export type ReifiedAtomTerm =
+  ReifiedAWildcard
+  | ReifiedAVar
+  | ReifiedARecord
+  | ReifiedAConstant
+  | ReifiedAApp
+  | ReifiedATuple
+  | ReifiedAMap;
+
+export interface ReifiedAWildcard {
+  tag: 'Wildcard';
+  vildcardId: string;
+}
+export interface ReifiedAVar {
+  tag: 'Var';
+  variableId: string;
+}
+export interface ReifiedARecord {
+  tag: 'Record';
+  name: QualifiedName;
+  fields: [string, number][];
+}
+export interface ReifiedAConstant {
+  tag: 'Constant';
+  constant: number;
+}
+export interface ReifiedAApp {
+  tag: 'App';
+  name: QualifiedName;
+  arguments: number[];
+}
+export interface ReifiedATuple {
+  tag: 'Tuple';
+  elements: number[];
+}
+export interface ReifiedAMap{
+  tag: 'Map';
+  nativeMap: [number, number][];
+}
+
+export type ReifiedContract =
+  ReifiedSuccess
+  | ReifiedFailure
+  | ReifiedCVar
+  | ReifiedCApp
+  | ReifiedPrefix
+  | ReifiedBin
+  | ReifiedLet;
+
+export interface ReifiedSuccess {
+  tag: 'Success';
+}
+
+export interface ReifiedFailure {
+  tag: 'Failure';
+}
+
+export interface ReifiedCVar {
+  tag: 'Var';
+  name: QualifiedName;
+}
+
+export interface ReifiedCApp {
+  tag: 'App';
+  name: QualifiedName;
+  contractArgs: number[];
+  expressionArgs: number[];
+}
+
+export interface ReifiedPrefix {
+  tag: 'Prefix';
+  agent: ReifiedAgentMatcher;
+  eventName: string | undefined;
+  eventType: Type;
+  whereExpression: number | undefined;
+  thenContract: number;
+}
+
+export interface ReifiedBin {
+  tag: 'Bin';
+  operator: ContractBinOp;
+  lhs: number;
+  rhs: number;
+}
+
+export interface ReifiedLet {
+  tag: 'Let';
+  definitions: ReifiedDef[];
+  bodyContract: number;
+}
+
+export type ReifiedAgentMatcher =
+  ReifiedAnyAgent
+  | ReifiedMatchAgent;
+
+export interface ReifiedAnyAgent {
+  tag: 'AnyAgent';
+}
+
+export interface ReifiedMatchAgent {
+  tag: 'ReifiedMatchAgent';
+  expression: number;
+}
+
+export type ContractBinOp =
+  And
+  | Or
+  | Then;
+
+export interface And {
+  tag: 'And';
+}
+
+export interface Or {
+  tag: 'Or';
+}
+
+export interface Then {
+  tag: 'Then';
+}
+
+export type ReifiedDef =
+  ReifiedContractDef
+  | ReifiedTemplateDef
+  | ReifiedValDef;
+
+export interface ReifiedContractDef {
+  tag: 'ReifiedContractDef';
+  defRec: boolean;
+  defContractBindings: ReifiedContractBinding[];
+}
+
+export interface ReifiedTemplateDef {
+  tag: 'ReifiedTemplateDef';
+  defRec: boolean;
+  defTemplateBindings: ReifiedTemplateBinding[];
+}
+
+export interface ReifiedValDef {
+  tag: 'ReifiedValDef';
+  defRec: boolean;
+  defValBindings: ReifiedValBinding[];
+}
+
+export interface ReifiedContractBinding {
+  name: string;
+  body: number;
+}
+
+export interface ReifiedTemplateBinding {
+  name: string;
+  isEntrypoint: boolean;
+  templateParams: string[];
+  expressionParams: string[];
+  body: number;
+}
+
+export interface ReifiedValBinding {
+  name: string;
+  isReport: boolean;
+  expression: number;
 }
 
 /* Contracts */

--- a/lib/Reflect.ts
+++ b/lib/Reflect.ts
@@ -12,7 +12,7 @@ import {
 import { ExternalObject } from './ExternalObject';
 
 export class Reflect {
-  constructor(private heap: ReifiedHeap, private entities: { [id: string] : ExternalObject }) { }
+  constructor(private heap: ReifiedHeap, private symbols: { [id: string] : ExternalObject }) { }
   reflect = (exp: ReifiedExp): Exp => {
     switch (exp.tag) {
       case 'App': return {
@@ -97,7 +97,7 @@ export class Reflect {
       };
       case 'Quote': return {
         tag: 'CQuote',
-        value: Object.keys(this.entities)[constant.symbol],
+        value: Object.keys(this.symbols)[constant.symbol],
       };
     }
   }

--- a/lib/Reflect.ts
+++ b/lib/Reflect.ts
@@ -148,7 +148,7 @@ export class Reflect {
         variableId: atomTern.variableId,
       };
       case 'Map': {
-        const d = [...atomTern.nativeMap].map(([k, v]) =>
+        const d = [...atomTern.entries].map(([k, v]) =>
           [
             this.reflectAtomTerm(this.heap.hAtomTerm[k]),
             this.reflectAtomTerm(this.heap.hAtomTerm[v]),
@@ -156,7 +156,7 @@ export class Reflect {
         );
         return {
           tag: 'Map',
-          nativeMap: d,
+          entries: d,
         };
       }
     }

--- a/lib/Reflect.ts
+++ b/lib/Reflect.ts
@@ -1,0 +1,149 @@
+import { ReifiedHeap, ReifiedExp, Exp, ReifiedConstant, Constant, ReifiedAtomTerm, AtomTerm, ReifiedAgentMatcher, AgentMatcher } from './DeonData';
+import { ExternalObject } from './ExternalObject';
+
+export class Reflect {
+  constructor(private heap: ReifiedHeap, private entities: { [id: string] : ExternalObject }) { }
+  reflect = (exp: ReifiedExp): Exp => {
+    switch (exp.tag) {
+      case 'App': return {
+        tag: 'EApp',
+        expression: this.reflect(this.heap.hExp[exp.expression]),
+        arg: this.reflect(this.heap.hExp[exp.arg]),
+      };
+      case 'BuiltInApp': return {
+        tag: 'EBuiltInApp',
+        builtInName: exp.builtInName,
+        args: exp.args.map(e => this.reflect(this.heap.hExp[e])),
+      };
+      case 'Constant': return {
+        tag: 'EConstant',
+        constant: this.reflectConstant(this.heap.hConstant[exp.constant]),
+      };
+      case 'Constructor': return {
+        tag: 'EConstructor',
+        constructorName: exp.constructorName,
+      };
+      case 'Lambda': return {
+        tag: 'ELambda',
+        cases: exp.cases.map((c) => {
+          return {
+            pattern: c.pattern,
+            expression: this.reflect(this.heap.hExp[c.expression]),
+          };
+        }),
+      };
+      case 'Project': return {
+        tag: 'EProject',
+        expression: this.reflect(this.heap.hExp[exp.expression]),
+        field: exp.field,
+      };
+      case 'Query': return {
+        tag: 'EQuery',
+        bodyExp: this.reflect(this.heap.hExp[exp.bodyExp]),
+        ruleName: exp.ruleName,
+        ruleTerm: this.reflectAtomTerm(this.heap.hAtomTerm[exp.ruleTerm]),
+      };
+      case 'Record': return {
+        tag: 'ERecord',
+        type: exp.type,
+        fields: exp.fields.map((f) => {
+          return {
+            name: f.name,
+            expression: this.reflect(this.heap.hExp[f.expression]),
+          };
+        }),
+      };
+      case 'Tuple': return {
+        tag: 'ETuple',
+        values: exp.values.map(v => this.reflect(this.heap.hExp[v])),
+      };
+      case 'Var': return {
+        tag: 'EVar',
+        qualifiedName: exp.qualifiedName,
+      };
+    }
+  }
+  reflectConstant = (constant: ReifiedConstant): Constant => {
+    switch (constant.tag) {
+      case 'Int': return {
+        tag: 'CInt',
+        value: constant.value,
+      };
+      case 'String': return {
+        tag: 'CString',
+        value: constant.value,
+      };
+      case 'Float': return {
+        tag: 'CFloat',
+        value: constant.value,
+      };
+      case 'DateTime': return {
+        tag: 'CDateTime',
+        value: constant.instant,
+      };
+      case 'Duration': return {
+        tag: 'CDuration',
+        value: constant.duration,
+      };
+      case 'Quote': return {
+        tag: 'CQuote',
+        value: Object.keys(this.entities)[constant.symbol],
+      };
+    }
+  }
+  reflectAtomTerm = (atomTern: ReifiedAtomTerm): AtomTerm => {
+    switch (atomTern.tag) {
+      case 'Wildcard': return {
+        tag: 'Wildcard',
+        wildcardId: atomTern.vildcardId,
+      };
+      case 'App': return {
+        tag: 'App',
+        name: atomTern.name,
+        arguments: atomTern.arguments.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
+      };
+      case 'Constant': return {
+        tag: 'Constant',
+        constant: this.reflectConstant(this.heap.hConstant[atomTern.constant]),
+      };
+      case 'Record': return {
+        tag: 'Record',
+        name: atomTern.name,
+        fields: Object.assign({}, ...Object.keys(atomTern.fields).map(
+          k => ({ [k]: this.reflectAtomTerm(this.heap.hAtomTerm[atomTern.fields[k]]) }),
+        )),
+      };
+      case 'Tuple': return {
+        tag: 'Tuple',
+        elements: atomTern.elements.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
+      };
+      case 'Var': return {
+        tag: 'Var',
+        variableId: atomTern.variableId,
+      };
+      case 'Map': {
+        const d = [...atomTern.nativeMap].map(([k, v]) =>
+          [
+            this.reflectAtomTerm(this.heap.hAtomTerm[k]),
+            this.reflectAtomTerm(this.heap.hAtomTerm[v]),
+          ] as [AtomTerm, AtomTerm],
+        );
+        return {
+          tag: 'Map',
+          nativeMap: d,
+        };
+      }
+    }
+  }
+  reflectAgentMatcher = (agentMatcher: ReifiedAgentMatcher): AgentMatcher => {
+    switch (agentMatcher.tag) {
+      case 'AnyAgent': return {
+        tag: 'AnyAgent',
+      };
+      case 'MatchAgent': return {
+        tag: 'MatchAgent',
+        expression: this.reflect(this.heap.hExp[agentMatcher.expression]),
+      }
+    }
+  }
+}

--- a/lib/Reflect.ts
+++ b/lib/Reflect.ts
@@ -117,38 +117,38 @@ export class Reflect {
       };
     }
   }
-  reflectAtomTerm = (atomTern: ReifiedAtomTerm): AtomTerm => {
-    switch (atomTern.tag) {
+  reflectAtomTerm = (atomTerm: ReifiedAtomTerm): AtomTerm => {
+    switch (atomTerm.tag) {
       case 'Wildcard': return {
         tag: 'Wildcard',
-        wildcardId: atomTern.vildcardId,
+        wildcardId: atomTerm.vildcardId,
       };
       case 'App': return {
         tag: 'App',
-        name: atomTern.name,
-        arguments: atomTern.arguments.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
+        name: atomTerm.name,
+        arguments: atomTerm.arguments.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
       };
       case 'Constant': return {
         tag: 'Constant',
-        constant: this.reflectConstant(this.heap.hConstant[atomTern.constant]),
+        constant: this.reflectConstant(this.heap.hConstant[atomTerm.constant]),
       };
       case 'Record': return {
         tag: 'Record',
-        name: atomTern.name,
-        fields: Object.assign({}, ...Object.keys(atomTern.fields).map(
-          k => ({ [k]: this.reflectAtomTerm(this.heap.hAtomTerm[atomTern.fields[k]]) }),
+        name: atomTerm.name,
+        fields: Object.assign({}, ...Object.keys(atomTerm.fields).map(
+          k => ({ [k]: this.reflectAtomTerm(this.heap.hAtomTerm[atomTerm.fields[k]]) }),
         )),
       };
       case 'Tuple': return {
         tag: 'Tuple',
-        elements: atomTern.elements.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
+        elements: atomTerm.elements.map(r => this.reflectAtomTerm(this.heap.hAtomTerm[r])),
       };
       case 'Var': return {
         tag: 'Var',
-        variableId: atomTern.variableId,
+        variableId: atomTerm.variableId,
       };
       case 'Map': {
-        const d = [...atomTern.entries].map(([k, v]) =>
+        const d = [...atomTerm.entries].map(([k, v]) =>
           [
             this.reflectAtomTerm(this.heap.hAtomTerm[k]),
             this.reflectAtomTerm(this.heap.hAtomTerm[v]),
@@ -159,6 +159,10 @@ export class Reflect {
           entries: d,
         };
       }
+      case 'Set': return {
+        tag: 'Set',
+        entries: atomTerm.entries.map(e => this.reflectAtomTerm(this.heap.hAtomTerm[e])),
+      };
     }
   }
   reflectAgentMatcher = (agentMatcher: ReifiedAgentMatcher): AgentMatcher => {

--- a/lib/Reflect.ts
+++ b/lib/Reflect.ts
@@ -1,4 +1,14 @@
-import { ReifiedHeap, ReifiedExp, Exp, ReifiedConstant, Constant, ReifiedAtomTerm, AtomTerm, ReifiedAgentMatcher, AgentMatcher } from './DeonData';
+import {
+  ReifiedHeap,
+  ReifiedExp,
+  Exp,
+  ReifiedConstant,
+  Constant,
+  ReifiedAtomTerm,
+  AtomTerm,
+  ReifiedAgentMatcher,
+  AgentMatcher,
+ } from './DeonData';
 import { ExternalObject } from './ExternalObject';
 
 export class Reflect {
@@ -143,7 +153,7 @@ export class Reflect {
       case 'MatchAgent': return {
         tag: 'MatchAgent',
         expression: this.reflect(this.heap.hExp[agentMatcher.expression]),
-      }
+      };
     }
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,4 +10,5 @@ export * from './Signed';
 export * from './ECDSA';
 export * from './Keys';
 export * from './ExternalObject';
+export * from './Reflect';
 export { ISO8601Duration };


### PR DESCRIPTION
To support retrieving residual runtime contracts, we need data structures that support the reified format. The data structures introduced here, mirror the ones introduced in https://gitlab.deondigital.com/deon/development/deon-dsl/-/merge_requests/1694

This also adds a `residualContract` field to `EventPredicate`.