### PR TITLE
Issue 143

### DIFF
--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -7,7 +7,7 @@ export interface AnonymousDeonApi {
   getDeclaration(id: string): Promise<D.Declaration>;
 
   getOntology(id: string): Promise<D.Ontology>;
-  getOntologyForCSL(input: string): Promise<D.Ontology>;
+  getOntologyForCSL(input: D.OntologyRequest): Promise<D.Ontology>;
 
   checkContract(i: D.CheckExpressionInput): Promise<CheckResponse>;
   checkExpression(i: D.CheckExpressionInput, id?: string): Promise<CheckResponse>;

--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -7,7 +7,7 @@ export interface AnonymousDeonApi {
   getDeclaration(id: string): Promise<D.Declaration>;
 
   getOntology(id: string): Promise<D.Ontology>;
-  getOntologyForCSL(csl: string): Promise<D.Ontology>;
+  getOntologyForCSL(input: string): Promise<D.Ontology>;
   
   checkContract(i: D.CheckExpressionInput): Promise<CheckResponse>;
   checkExpression(i: D.CheckExpressionInput, id?: string): Promise<CheckResponse>;

--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -7,7 +7,8 @@ export interface AnonymousDeonApi {
   getDeclaration(id: string): Promise<D.Declaration>;
 
   getOntology(id: string): Promise<D.Ontology>;
-
+  getOntologyForCSL(csl: string): Promise<D.Ontology>;
+  
   checkContract(i: D.CheckExpressionInput): Promise<CheckResponse>;
   checkExpression(i: D.CheckExpressionInput, id?: string): Promise<CheckResponse>;
 

--- a/lib/DeonApi.ts
+++ b/lib/DeonApi.ts
@@ -8,7 +8,7 @@ export interface AnonymousDeonApi {
 
   getOntology(id: string): Promise<D.Ontology>;
   getOntologyForCSL(input: string): Promise<D.Ontology>;
-  
+
   checkContract(i: D.CheckExpressionInput): Promise<CheckResponse>;
   checkExpression(i: D.CheckExpressionInput, id?: string): Promise<CheckResponse>;
 

--- a/lib/DeonApiMock.ts
+++ b/lib/DeonApiMock.ts
@@ -36,6 +36,7 @@ export const anonymousApiMock: AnonymousDeonApi = {
   getDeclarations: (): Promise<Declaration[]> => Promise.reject(),
   getDeclaration: (_0: string): Promise<Declaration> => Promise.reject(),
   getOntology: (_0: string): Promise<Ontology> => Promise.reject(),
+  getOntologyForCSL: (_0: string): Promise<Ontology> => Promise.reject(),
   checkContract: (_0: CheckExpressionInput): Promise<CheckResponse> => Promise.reject(),
   checkExpression: (_0: CheckExpressionInput, _1?: string): Promise<CheckResponse> =>
     Promise.reject(),

--- a/lib/DeonApiMock.ts
+++ b/lib/DeonApiMock.ts
@@ -21,6 +21,7 @@ import {
   Value,
   CheckExpressionInput,
   ResidualSource,
+  OntologyRequest,
   } from './DeonData';
 import { ExternalObject } from './ExternalObject';
 
@@ -36,7 +37,7 @@ export const anonymousApiMock: AnonymousDeonApi = {
   getDeclarations: (): Promise<Declaration[]> => Promise.reject(),
   getDeclaration: (_0: string): Promise<Declaration> => Promise.reject(),
   getOntology: (_0: string): Promise<Ontology> => Promise.reject(),
-  getOntologyForCSL: (_0: string): Promise<Ontology> => Promise.reject(),
+  getOntologyForCSL: (_0: OntologyRequest): Promise<Ontology> => Promise.reject(),
   checkContract: (_0: CheckExpressionInput): Promise<CheckResponse> => Promise.reject(),
   checkExpression: (_0: CheckExpressionInput, _1?: string): Promise<CheckResponse> =>
     Promise.reject(),

--- a/lib/DeonData.ts
+++ b/lib/DeonData.ts
@@ -5,6 +5,10 @@ import { ExternalObject } from './ExternalObject';
 import { stringifyCanonically } from './CanonicalJSON';
 
 /* API Input and output wrappers */
+export interface OntologyRequest {
+  csl: string;
+}
+
 export interface DeclarationInput {
   csl: string;
   name: string;

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -136,7 +136,7 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
   }
   getOntologyForCSL(input: string): Promise<Ontology> {
       return this.http.post(`/declarations/ontology`, {csl: input})
-        .then(possiblyNotFound);
+        .then(possiblyBadRequest);
     }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {
     return this.http.post('/csl/check', i)

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -134,6 +134,10 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
     return this.http.get(`/declarations/${id}/ontology`)
       .then(possiblyNotFound);
   }
+  getOntologyForCSL(csl: string): Promise<Ontology> {
+      return this.http.post('/declarations/ontology', {input: csl})
+        .then(possiblyNotFound);
+    }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {
     return this.http.post('/csl/check', i)
       .then(checkHandler);

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -135,9 +135,9 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
       .then(possiblyNotFound);
   }
   getOntologyForCSL(input: string): Promise<Ontology> {
-      return this.http.post(`/declarations/ontology`, {csl: input})
-        .then(possiblyBadRequest);
-    }
+    return this.http.post('/declarations/ontology', { csl: input })
+      .then(possiblyBadRequest);
+  }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {
     return this.http.post('/csl/check', i)
       .then(checkHandler);

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -134,8 +134,8 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
     return this.http.get(`/declarations/${id}/ontology`)
       .then(possiblyNotFound);
   }
-  getOntologyForCSL(csl: string): Promise<Ontology> {
-      return this.http.post('/declarations/ontology', {input: csl})
+  getOntologyForCSL(input: string): Promise<Ontology> {
+      return this.http.post(`/declarations/ontology`, {csl: input})
         .then(possiblyNotFound);
     }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -29,6 +29,7 @@ import {
   EventPredicate,
   Value,
   ResidualSource,
+  OntologyRequest,
 } from './DeonData';
 import { HttpClient, Response } from './HttpClient';
 import { ExternalObject } from './ExternalObject';
@@ -134,8 +135,8 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
     return this.http.get(`/declarations/${id}/ontology`)
       .then(possiblyNotFound);
   }
-  getOntologyForCSL(input: string): Promise<Ontology> {
-    return this.http.post('/declarations/ontology', { csl: input })
+  getOntologyForCSL(input: OntologyRequest): Promise<Ontology> {
+    return this.http.post('/declarations/ontology', input)
       .then(possiblyBadRequest);
   }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {


### PR DESCRIPTION
Add helper for new endpoint. Endpoint gets an ontology from a CSL string, currently this can only be done for a saved declaration.