### PR TITLE
Moved host for getOntolgyForCSL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
 ### Unreleased
 
 * Parameterize Case over type of body.
-* Added endpoint for `getOntologyForCSL`.
+* Added endpoint for `/csl/ontology`.
 
 ### [16.1.0] - 2020-09-10
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 ### Unreleased
 
 * Parameterize Case over type of body.
+* Added endpoint for `getOntologyForCSL`.
 
 ### [16.1.0] - 2020-09-10
 

--- a/lib/DeonRestClient.ts
+++ b/lib/DeonRestClient.ts
@@ -136,7 +136,7 @@ export class AnonymousDeonRestClient implements AnonymousDeonApi {
       .then(possiblyNotFound);
   }
   getOntologyForCSL(input: OntologyRequest): Promise<Ontology> {
-    return this.http.post('/declarations/ontology', input)
+    return this.http.post('/csl/ontology', input)
       .then(possiblyBadRequest);
   }
   checkContract(i: CheckExpressionInput): Promise<CheckResponse> {


### PR DESCRIPTION
Moved host for getOntolgyForCSL to CSL from declaration, and added an entry in the README for getOntolgyForCSL.